### PR TITLE
Add pointer to file on EOS and only store the minimal output

### DIFF
--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -61,6 +61,12 @@ following command:
 wget https://key4hep.web.cern.ch/tutorial/zh_mumu_ild_dst/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I402004.Pe2e2h.eR.pL.n000.d_dstm_15090_0.edm4hep.root
 ```
 
+**If you are running on lxplus the file is also available on EOS:**
+
+```
+/eos/project-k/key4hep/www/key4hep/tutorial/zh_mumu_ild_dst/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I402004.Pe2e2h.eR.pL.n000.d_dstm_15090_0.edm4hep.root
+```
+
 To run the Higgs recoil process change the location of the input data in the
 following file and then run:
 

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -33,6 +33,13 @@ inp.collections = [
 ]
 
 out = PodioOutput("out")
+out.outputCommands = [
+    "drop *",
+    "keep Muons",
+    "keep PandoraPFOs",
+    "keep Z",
+    "keep Higgs",
+]
 out.filename = "higgs_recoil_out.root"
 
 # The collections that we don't drop will be present in the output file


### PR DESCRIPTION
Point people to the file on EOS so that they do not have to download it first. Also adjust the PodioOutput to only store what is strictly necessary. (Improves runtime quite a bit). Also works around https://github.com/key4hep/k4FWCore/issues/150