### PR TITLE
Include link to podio documentation

### DIFF
--- a/edm4hep_analysis/edm4hep_api_intro.md
+++ b/edm4hep_analysis/edm4hep_api_intro.md
@@ -9,6 +9,7 @@ to give you the knowledge to make sense of it.
 
 - EDM4hep doxygen API reference page: [edm4hep.web.cern.ch](https://edm4hep.web.cern.ch)
 - EDM4hep github repository: [github.com/key4hep/EDM4hep](https://github.com/key4hep/EDM4hep)
+- podio documentation page (including API reference): [key4hep.web.cern.ch/podio](https://key4hep.web.cern.ch/podio)
 - podio github repository: [github.com/AIDASoft/podio](https://github.com/AIDASoft/podio)
 
 ## Doxygen API documentation


### PR DESCRIPTION
BEGINRELEASENOTES
- Include a link to the podio documentation in the EDM4hep / podio how-to

ENDRELEASENOTES
