### PR TITLE
Use latest release instead of nightlies.

### DIFF
--- a/edm4hep_analysis/README.md
+++ b/edm4hep_analysis/README.md
@@ -13,7 +13,7 @@ Make sure that you are in a Key4hep software environment. If you are not yet, a
 simple way to get into one is to
 
 ```bash
-source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
 ```
 
 afterwards create a working directory for this exercise

--- a/whizard_gen/README.md
+++ b/whizard_gen/README.md
@@ -14,7 +14,7 @@ events for the process
 If you haven't done it yet, source a Key4hep software environment via
 
 ```bash
-source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
 ```
 
 and create a working directory for this exercise:


### PR DESCRIPTION
Ensure all tutorials are using the latest release instead of nightlies.

Fixes https://github.com/key4hep/key4hep-tutorials/issues/14.