### PR TITLE
Update tutorials to use IOSvc and functional algorithms

### DIFF
--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -87,8 +87,8 @@ instructions for what algorithms we want to run, what parameters we want to pass
 them and other configuration like logging.
 
 There are several options that can be changed in the steering file that may be important:
-- The name of the input file is passed to the `PodioInput` plugin
-- The name of the output file is passed to the `PodioOutput` plugin
+- The name of the input file is passed to the `IOSvc` service
+- The name of the output file is passed to the `IOSvc` service
 - The number of events to process is passed to the `ApplicationMgr`. Choose `-1`
   not to limit it (all the events in the input file will be processed) or any
   other number to put a limit (sometimes useful for testing or debugging)

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -24,7 +24,7 @@ intermediate collection with the muons.
 
 First, we will need a key4hep setup, typically obtained by sourcing scripts from
 cvmfs, see the instructions
-[here](https://key4hep.github.io/key4hep-doc/setup-and-getting-started/README.html).
+[here](https://key4hep.github.io/key4hep-doc/getting_started/setup.html).
 After sourcing, check that the environment variable `KEY4HEP_STACK` is set to
 make sure the stack has been loaded correctly:
 

--- a/gaudi_alg_higgs/setup/higgs_recoil/CMakeLists.txt
+++ b/gaudi_alg_higgs/setup/higgs_recoil/CMakeLists.txt
@@ -7,7 +7,6 @@ set(sources components/HiggsRecoil.cpp
 gaudi_add_module(tutorial
                  SOURCES ${sources}
                  LINK Gaudi::GaudiKernel
-                      Gaudi::GaudiAlgLib
                       k4FWCore::k4FWCore
                       EDM4HEP::edm4hep
                       EDM4HEP::utils

--- a/gaudi_alg_higgs/setup/higgs_recoil/components/MuonFilter.cpp
+++ b/gaudi_alg_higgs/setup/higgs_recoil/components/MuonFilter.cpp
@@ -18,23 +18,21 @@
  */
 
 #include "Gaudi/Property.h"
-#include "GaudiAlg/Transformer.h"
 
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/utils/kinematics.h"
 
-// Define BaseClass_t
-#include "k4FWCore/BaseClass.h"
+#include "k4FWCore/Transformer.h"
 
 #include <string>
 
 struct MuonFilter final
-  : Gaudi::Functional::Transformer<edm4hep::ReconstructedParticleCollection(const edm4hep::ReconstructedParticleCollection&), BaseClass_t> {
+  : public k4FWCore::Transformer<edm4hep::ReconstructedParticleCollection(const edm4hep::ReconstructedParticleCollection&)> {
   MuonFilter(const std::string& name, ISvcLocator* svcLoc)
       : Transformer(
             name, svcLoc,
-            {KeyValue("InputPFOs", "PandoraPFOs")},
-            {KeyValue("OutputMuons", "Muons")}) {
+            {KeyValues("InputPFOs", {"PandoraPFOs"})},
+            {KeyValues("OutputMuons", {"Muons"})}) {
   }
 
   edm4hep::ReconstructedParticleCollection operator()(const edm4hep::ReconstructedParticleCollection& recoColl) const override {

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -19,31 +19,26 @@
 
 from Gaudi.Configuration import INFO
 from Configurables import HiggsRecoil, MuonFilter
-from Configurables import ApplicationMgr
-from Configurables import k4DataSvc
-from Configurables import PodioOutput
-from Configurables import PodioInput
+from k4FWCore import ApplicationMgr, IOSvc
 
-data_svc = k4DataSvc("EventDataSvc")
-data_svc.input = "/home/juanmi/Downloads/ZH_40_events_ILD_DST_merged.edm4hep.root"
+io_svc = IOSvc()
+io_svc.Input = "rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I402004.Pe2e2h.eR.pL.n000.d_dstm_15090_0.edm4hep.root"
 
-inp = PodioInput()
-inp.collections = [
+io_svc.CollectionNames = [
     "PandoraPFOs",
 ]
 
-out = PodioOutput("out")
-out.outputCommands = [
+io_svc.outputCommands = [
     "drop *",
     "keep Muons",
     "keep PandoraPFOs",
     "keep Z",
     "keep Higgs",
 ]
-out.filename = "higgs_recoil_out.root"
+io_svc.Output = "higgs_recoil_out.root"
 
 # The collections that we don't drop will be present in the output file
-# out.outputCommands = ["drop Collection1"]
+# io_svc.outputCommands = ["drop Collection1"]
 
 # If we don't specify the values for the name parameters
 # they will take the default value defined in the C++ code
@@ -58,9 +53,9 @@ recoil = HiggsRecoil("HiggsRecoil",
                      ZCollection=["Z"],
                      )
 
-ApplicationMgr(TopAlg=[inp, muon, recoil, out],
+ApplicationMgr(TopAlg=[muon, recoil],
                EvtSel="NONE",
                EvtMax=-1,
-               ExtSvc=[data_svc],
+               ExtSvc=[],
                OutputLevel=INFO,
                )

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -48,14 +48,14 @@ out.filename = "higgs_recoil_out.root"
 # If we don't specify the values for the name parameters
 # they will take the default value defined in the C++ code
 muon = MuonFilter("MuonFilter",
-                 InputPFOs="PandoraPFOs",
-                 OutputMuons="Muons",
+                 InputPFOs=["PandoraPFOs"],
+                 OutputMuons=["Muons"],
                  MinPt=10.0)
 
 recoil = HiggsRecoil("HiggsRecoil",
-                     InputMuons="Muons",
-                     HiggsCollection="Higgs",
-                     ZCollection="Z",
+                     InputMuons=["Muons"],
+                     HiggsCollection=["Higgs"],
+                     ZCollection=["Z"],
                      )
 
 ApplicationMgr(TopAlg=[inp, muon, recoil, out],

--- a/gaudi_ild_reco/.solution/MarlinStdReco.py
+++ b/gaudi_ild_reco/.solution/MarlinStdReco.py
@@ -1,18 +1,15 @@
 import os
 from Gaudi.Configuration import *
-
 from Configurables import (
-    PodioInput,
-    PodioOutput,
-    k4DataSvc,
     MarlinProcessorWrapper,
     EDM4hep2LcioTool,
     Lcio2EDM4hepTool,
 )
 from k4MarlinWrapper.parseConstants import *
 
+from k4FWCore import IOSvc
+
 algList = []
-evtsvc = k4DataSvc("EventDataSvc")
 
 
 CONSTANTS = {
@@ -134,9 +131,9 @@ CONSTANTS = {
 
 parseConstants(CONSTANTS)
 
-read = PodioInput()
-read.OutputLevel = INFO
-read.collections = [
+io_svc = IOSvc()
+io_svc.OutputLevel = INFO
+io_svc.CollectionNames = [
     "BeamCalCollection",
     "BeamCalCollectionContributions",
     "ECalBarrelScHitsEven",
@@ -187,8 +184,13 @@ read.collections = [
     "YokeEndcapsCollection",
     "YokeEndcapsCollectionContributions",
 ]
-
-algList.append(read)
+io_svc.Output = "zh_mumu_reco.edm4hep.root"
+io_svc.outputCommands = [
+    "drop *",
+    "keep MCParticlesSkimmed",
+    "keep PandoraPFOs",
+    "keep RecoMCTruthLink",
+]
 
 edm4hep2LcioConv = EDM4hep2LcioTool()
 edm4hep2LcioConv.collNameMapping = {"MCParticles": "MCParticle"}
@@ -1783,16 +1785,6 @@ lcio2edm4hepConv = Lcio2EDM4hepTool()
 lcio2edm4hepConv.collNameMapping = {"MCParticle": "MCParticles"}
 MyPfoAnalysis.Lcio2EDM4hepTool = lcio2edm4hepConv
 
-edm4hepOutput = PodioOutput()
-edm4hepOutput.OutputLevel = DEBUG
-edm4hepOutput.filename = "zh_mumu_reco.edm4hep.root"
-edm4hepOutput.outputCommands = [
-    "drop *",
-    "keep MCParticlesSkimmed",
-    "keep PandoraPFOs",
-    "keep RecoMCTruthLink",
-]
-
 
 algList.append(MyAIDAProcessor)
 algList.append(InitDD4hep)
@@ -1863,10 +1855,9 @@ algList.append(TOFEstimators100ps)
 algList.append(MyLCIOOutputProcessor)
 algList.append(DSTOutput)
 algList.append(MyPfoAnalysis)
-algList.append(edm4hepOutput)
 
-from Configurables import ApplicationMgr
+from k4FWCore import ApplicationMgr
 
 ApplicationMgr(
-    TopAlg=algList, EvtSel="NONE", EvtMax=10, ExtSvc=[evtsvc], OutputLevel=INFO
+    TopAlg=algList, EvtSel="NONE", EvtMax=10, ExtSvc=[], OutputLevel=INFO
 )

--- a/gaudi_ild_reco/README.md
+++ b/gaudi_ild_reco/README.md
@@ -228,16 +228,9 @@ resp. The corresponding filename constants values in `CONSTANTS`.
 ### Adapting the options file for EDM4hep
 
 It is necessary to adapt the Gaudi options file a bit further:
-- Replace the `LcioEvent` algorithm with the `PodioInput` algorithm 
-  - Make sure to replace the `Files` option with the `collections` option and to
-    populate this option with the list of collections you want to read (see
-    below)
-- Replace the `EventDataSvc` with the `k4DataSvc` (remember to instantiate it
-  with `"EventDataSvc"` as name)
-- Add a `PodioOutput` algorithm to write EDM4hep output (don't forget to add it
-  to the `algList` at the very end)
-  - (For the sake of this exercise) configure this to only write the
-    `MCParticlesSkimmed`, `PandoraPFOs` and the `RecoMCTruthLink` collections
+- Remove the `LcioEvent` algorithm and create the `IOSvc` service
+  - Populate the `CollectionNames` property of `IOSvc` with the list of collections you want to read (see below).
+  - Use `Output` property of `IOSvc` to specify to which file write the EDM4hep output. (For the sake of this exercise) configure the `outputCommands` property to only write the `MCParticlesSkimmed`, `PandoraPFOs` and the `RecoMCTruthLink` collections.
 - Attach the necessary in-memory on-the-fly converters between EDM4hep and LCIO
   (and vice versa)
   - For the conversion of the EDM4hep inputs to LCIO instantiate a
@@ -247,33 +240,42 @@ It is necessary to adapt the Gaudi options file a bit further:
     `Lcio2EDM4hepTool` and attach it to the last wrapped processor that is run
     before the `PodioOutput` algorithm that you just added (`MyPfoAnalysis`).
     Also see below.
+- Near the end of the file replace the `from Configurables import ApplicationMgr` with `from k4FWCore import ApplicationMgr`.
     
 **For all of these steps make sure that you `import` all the necessary tools and
-algorithms from `Configurables`!**
+algorithms from `Configurables`! Both `IOSvc` and `ApplicationMgr` services should be imported from `k4FWCore`.**
   
 The top of your file should now look something like this
 
 ```python
 from Configurables import (
-    PodioInput, PodioOutput, k4DataSvc, MarlinProcessorWrapper,
+    MarlinProcessorWrapper,
     EDM4hep2LcioTool, Lcio2EDM4hepTool
     )
 from k4MarlinWrapper.parseConstants import *
+from k4FWCore import IOSvc
+
 algList = []
-evtsvc = k4DataSvc("EventDataSvc")
+
+io_svc = IOSvc()
+io_svc.OutputLevel = INFO
+io_svc.CollectionNames = [
+    # ... list of collection names
+]
+
+io_svc.Output = "zh_mumu_reco.edm4hep.root"
+io_svc.outputCommands = [
+    "drop *",
+    "keep MCParticlesSkimmed",
+    "keep PandoraPFOs",
+    "keep RecoMCTruthLink",
+]
 ```
 
-while the configuration for the input reader and the `EDM4hep2LcioTool` should
+while the configuration for the `EDM4hep2LcioTool` should
 look like this
 
 ```python
-read = PodioInput()
-read.OutputLevel = INFO
-read.collections = [
-    # ... list of collection names
-]
-algList.append(read)
-
 edm4hep2LcioConv = EDM4hep2LcioTool()
 edm4hep2LcioConv.collNameMapping = {
     "MCParticles": "MCParticle"
@@ -290,7 +292,7 @@ The list of collections that is populated by standard configuration of ILD for
 simulation looks like this. You can simply copy this into the options file
 
 ```python
-read.collections = [
+io_svc.CollectionNames = [
      "BeamCalCollection",
      "BeamCalCollectionContributions",
      "ECalBarrelScHitsEven",
@@ -345,8 +347,7 @@ read.collections = [
 
 :::
 
-Finally, the `PodioOutput` algorithm and the `Lcio2EDM4hepTool` can be
-configuration should look something like this
+Finally, the `Lcio2EDM4hepTool` configuration and `ApplicationMgr` should look something like this
 
 ```python
 # ... MyPfoAnalysis configuration unchanged
@@ -357,19 +358,13 @@ lcio2edm4hepConv.collNameMapping = {
 }
 MyPfoAnalysis.Lcio2EDM4hepTool = lcio2edm4hepConv
 
-edm4hepOutput = PodioOutput()
-edm4hepOutput.filename = "zh_mumu_reco.edm4hep.root"
-edm4hepOutput.outputCommands = [
-    "drop *",
-    "keep MCParticlesSkimmed",
-    "keep PandoraPFOs",
-    "keep RecoMCTruthLink",
-]
+# algList unchanged
 
-# ... the complete algList
-algList.append(edm4hepOutput)
+from k4FWCore import ApplicationMgr
 
-# ... ApplicationMgr config
+ApplicationMgr(
+    TopAlg=algList, EvtSel="NONE", EvtMax=10, ExtSvc=[], OutputLevel=INFO
+)
 ```
 
 ### Running the reconstruction with `k4run`
@@ -378,7 +373,7 @@ After all these adaptions it is now possible to run the full reconstruction
 chain on the previously simulated input with `k4run`
 
 ```bash
-k4run MarlinStdReco.py --num-events=3 --EventDataSvc.input=zh_mumu_SIM.edm4hep.root
+k4run MarlinStdReco.py --num-events=3 --IOSvc.Input=zh_mumu_SIM.edm4hep.root
 ```
 
 Here we are again using the command line to specify the input file, we could
@@ -388,6 +383,6 @@ for [this issue](https://github.com/key4hep/k4MarlinWrapper/issues/94).
 
 You should now have a `zh_mumu_reco.edm4hep.root` file that contains the
 complete events in all their glory. For a more practical output you can tweak
-the `edm4hepOutput.outputCommands` option in order to keep only "interesting"
+the `io_svc.outputCommands` option in order to keep only "interesting"
 collections. Also note that the REC and DST LCIO output files are still
 produced. Can you reproduce these data tiers for EDM4hep?

--- a/gaudi_ild_reco/README.md
+++ b/gaudi_ild_reco/README.md
@@ -243,7 +243,7 @@ It is necessary to adapt the Gaudi options file a bit further:
 - Near the end of the file replace the `from Configurables import ApplicationMgr` with `from k4FWCore import ApplicationMgr`.
     
 **For all of these steps make sure that you `import` all the necessary tools and
-algorithms from `Configurables`! Both `IOSvc` and `ApplicationMgr` services should be imported from `k4FWCore`.**
+algorithms from `Configurables`! Both `IOSvc` and `ApplicationMgr` services must be imported from `k4FWCore`.**
   
 The top of your file should now look something like this
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Update algorithms be to functional k4FWCore algortihms
- Replace `k4DataSvc` with `IOSvc` in the tutorials
- Don't link deprecated and removed `GaudiAlg` library
- Fix broken link to documentation

ENDRELEASENOTES

Closes #22 

There seems to be two problems:
- [x] The input file to Gaudi tutorial is outdated and I can't check if this actually runs well with the `IOSvc`. #9
- [x] In the MarlinWrapper tutorial with `IOSvc` I get the errors:
  ```txt
  ApplicationMgr       INFO Application Manager Initialized successfully
  ApplicationMgr       INFO Application Manager Started successfully
  MyAIDAProcessor     DEBUG Retrieving LCIO Event for wrapped processor MyAIDAProcessor
  MyAIDAProcessor     DEBUG Registering empty Event for EDM4hep to LCIO conversion event in TES
  ToolSvc.EDM4hep...   INFO Converting all collections from EDM4hep to LCIO
  ToolSvc.EDM4hep...  DEBUG Converting collection BeamCalCollection (storing it as BeamCalCollection)
  ToolSvc.EDM4hep...  DEBUG Converting type edm4hep::CaloHitContribution from input BeamCalCollection
  ToolSvc.EDM4hep...  DEBUG CaloHitContribution collection cannot be converted standalone. SimCalorimeterHit collection to be converted in order to be able to attach to them
  ToolSvc.EDM4hep...  DEBUG Converting collection BeamCalCollectionContributions (storing it as BeamCalCollectionContributions)
  ToolSvc.EDM4hep...  DEBUG Converting type edm4hep::CaloHitContribution from input BeamCalCollectionContributions
  ToolSvc.EDM4hep...  DEBUG CaloHitContribution collection cannot be converted standalone. SimCalorimeterHit collection to be converted in order to be able to attach to them
  ToolSvc.EDM4hep...  DEBUG Converting collection ECalBarrelScHitsEven (storing it as ECalBarrelScHitsEven)
  ToolSvc.EDM4hep...  DEBUG Converting type edm4hep::SimCalorimeterHit from input ECalBarrelScHitsEven
  ToolSvc.EDM4hep...  DEBUG Converting collection ECalBarrelScHitsEvenContributions (storing it as ECalBarrelScHitsEvenContributions)
  ToolSvc.EDM4hep...  DEBUG Converting type edm4hep::CaloHitContribution from input ECalBarrelScHitsEvenContributions
  ToolSvc.EDM4hep...  DEBUG CaloHitContribution collection cannot be converted standalone. SimCalorimeterHit collection to be converted in order to be able to attach to them
  ToolSvc.EDM4hep...  DEBUG Converting collection ECalBarrelScHitsOdd (storing it as ECalBarrelScHitsOdd)
  ToolSvc.EDM4hep...  DEBUG Converting type edm4hep::SimCalorimeterHit from input ECalBarrelScHitsOdd
  ToolSvc.EDM4hep...  DEBUG Converting collection ECalBarrelScHitsOddContributions (storing it as ECalBarrelScHitsOddContributions)
  ToolSvc.EDM4hep...  DEBUG Converting type edm4hep::SimTrackerHit from input ECalBarrelScHitsOddContributions
  MyAIDAProcessor     FATAL  Exception with tag=MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available is caught 
  MyAIDAProcessor     ERROR MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available       MetaDataHandle empty handle access      StatusCode=FAILURE
  k4FWCore__Algs      FATAL  Exception with tag=MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available is caught 
  k4FWCore__Algs      ERROR MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available       MetaDataHandle empty handle access      StatusCode=FAILURE
  k4FWCore__Seque...  FATAL  Exception with tag=MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available is caught 
  k4FWCore__Seque...  ERROR MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available       MetaDataHandle empty handle access      StatusCode=FAILURE
  EventLoopMgr        FATAL .executeEvent(): Exception with tag=MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available thrown by k4FWCore__Sequencer
  EventLoopMgr        ERROR MetaDataHandle ECalBarrelScHitsOddContributions__CellIDEncoding not (yet?) available       MetaDataHandle empty handle access      StatusCode=FAILURE
  EventLoopMgr      WARNING Execution of algorithm k4FWCore__Sequencer failed
  EventLoopMgr        ERROR Error processing event loop.
  EventLoopMgr        ERROR Terminating event processing loop due to errors
  EventLoopMgr        ERROR Terminating event processing loop due to errors
  ApplicationMgr       INFO Application Manager Stopped successfully
  ...
  ApplicationMgr      ERROR Application Manager Terminated with error code 6
  ``` 
  With `k4DataSvc` it seems to run without issues. In the file created by following tutorial instructions there is no `ECalBarrelScHitsOddContributions__CellIDEncoding` metadata