### PR TITLE
Update gaudi alg tutorial

### DIFF
--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -87,8 +87,8 @@ instructions for what algorithms we want to run, what parameters we want to pass
 them and other configuration like logging.
 
 There are several options that can be changed in the steering file that may be important:
-- The name of the input file is passed to the `IOSvc` service
-- The name of the output file is passed to the `IOSvc` service
+- The name of the input file is passed to the `PodioInput` plugin
+- The name of the output file is passed to the `PodioOutput` plugin
 - The number of events to process is passed to the `ApplicationMgr`. Choose `-1`
   not to limit it (all the events in the input file will be processed) or any
   other number to put a limit (sometimes useful for testing or debugging)

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -92,7 +92,8 @@ There are several options that can be changed in the steering file that may be i
 After the processing has ran, we'll have an output file. We can inspect the file
 with `podio-dump` to see which collections it has. By default it will be a list of collections and parameters metadata:
 
-```txt
+```console
+$ podio-dump higgs_recoil_out.root
 input file: higgs_recoil_out.root
             (written with podio version: 1.3.0)
 

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -87,8 +87,8 @@ instructions for what algorithms we want to run, what parameters we want to pass
 them and other configuration like logging.
 
 There are several options that can be changed in the steering file that may be important:
-- The name of the input file is passed to the `PodioInput` plugin
-- The name of the output file is passed to the `PodioOutput` plugin
+- The name of the input file is passed to the `IOSvc` service
+- The name of the output file is passed to the `IOSvc` service
 - The number of events to process is passed to the `ApplicationMgr`. Choose `-1`
   not to limit it (all the events in the input file will be processed) or any
   other number to put a limit (sometimes useful for testing or debugging)

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -87,8 +87,8 @@ instructions for what algorithms we want to run, what parameters we want to pass
 them and other configuration like logging.
 
 There are several options that can be changed in the steering file that may be important:
-- The name of the input file is passed to the `PodioInput` plugin
-- The name of the output file is passed to the `PodioOutput` plugin
+- The name of the input file is passed to the `IOSvc` plugin
+- The name of the output file is passed to the `IOSvc` plugin
 - The number of events to process is passed to the `ApplicationMgr`. Choose `-1`
   not to limit it (all the events in the input file will be processed) or any
   other number to put a limit (sometimes useful for testing or debugging)
@@ -102,38 +102,33 @@ with `podio-dump` to see which collections it has. By default it will be a list 
 
 ```txt
 input file: higgs_recoil_out.root
-            (written with podio version: 1.2.99)
+            (written with podio version: 1.3.0)
 
-datamodel model definitions stored in this file: 
- - edm4hep (0.99.99)
+datamodel model definitions stored in this file:
+ - edm4hep (0.99.2)
 
 Frame categories in this file:
-Name                      Entries
-----------------------  ---------
-metadata                        1
-events                       9400
-configuration_metadata          1
+Name                    Entries
+----------------------  -------
+metadata                1        
+events                  9400     
+configuration_metadata  1        
 ################################### events: 0 ####################################
 Collections:
-Name         ValueType                         Size  ID
------------  ------------------------------  ------  --------
-Higgs        edm4hep::ReconstructedParticle       1  88d34b01
-Muons        edm4hep::ReconstructedParticle       2  aa8128c8
-PandoraPFOs  edm4hep::ReconstructedParticle      59  fa28d9be
-Z            edm4hep::ReconstructedParticle       1  3dbac09d
+Name         ValueType                       Size  ID
+-----------  ------------------------------  ----  --------
+Higgs        edm4hep::ReconstructedParticle  1     88d34b01
+Muons        edm4hep::ReconstructedParticle  2     aa8128c8
+PandoraPFOs  edm4hep::ReconstructedParticle  59    fa28d9be
+Z            edm4hep::ReconstructedParticle  1     3dbac09d
 
 Parameters:
-Name                            Type           Elements
-------------------------------  -----------  ----------
-_weight                         float                 1
-alphaQCD                        float                 1
-beam_particle1                  std::string           1
-beam_particle2                  std::string           1
-beamPDG1                        int                   1
-beamPDG2                        int                   1
-beamPol1                        float                 1
-beamPol2                        float                 1
-BeamSpectrum                    std::string           1
+Name                            Type         Elements
+------------------------------  -----------  -------
+beamPDG1                        int          1
+beamPDG2                        int          1
+Event Number                    int          1
+GenFileSerialNumber             int          1
 ...
 ```
 

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -47,17 +47,9 @@ cd key4hep-tutorials/gaudi_alg_higgs/setup
 We'll work from the `setup` directory in this folder. Once there, run
 
 ```
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=../install
-cmake --build . -j $(nproc) -t install 
-cd ../install
-export PATH=$PWD/bin:$PATH
-export LD_LIBRARY_PATH=$PWD/lib:$PWD/lib64:$LD_LIBRARY_PATH
-export ROOT_INCLUDE_PATH=$PWD/include:$ROOT_INCLUDE_PATH
-export PYTHONPATH=$PWD/python:$PYTHONPATH
-export CMAKE_PREFIX_PATH=$PWD:$CMAKE_PREFIX_PATH
-cd ../
+cmake -B build -S . -DCMAKE_INSTALL_PREFIX=$(pwd)/install
+cmake --build build -j $(nproc) -t install
+k4_local_repo
 ```
 
 Now we should have compiled our code. Two C++ files will have been compiled:

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -24,7 +24,7 @@ intermediate collection with the muons.
 
 First, we will need a key4hep setup, typically obtained by sourcing scripts from
 cvmfs, see the instructions
-[here](https://key4hep.github.io/key4hep-doc/main/setup-and-getting-started/README.html).
+[here](https://key4hep.github.io/key4hep-doc/main/getting_started/setup.html).
 After sourcing, check that the environment variable `KEY4HEP_STACK` is set to
 make sure the stack has been loaded correctly:
 

--- a/gaudi_alg_higgs/README.md
+++ b/gaudi_alg_higgs/README.md
@@ -98,38 +98,50 @@ There are several options that can be changed in the steering file that may be i
   that it isn't defined.
 
 After the processing has ran, we'll have an output file. We can inspect the file
-with `podio-dump` to see which collections it has. By default it will be a long
-list of collections since the collections of the input file are kept:
+with `podio-dump` to see which collections it has. By default it will be a list of collections and parameters metadata:
 
-```
-$ podio-dump higgs_recoil_out.root
-BCalClusters                              edm4hep::Cluster                                0  bc95eab6
-BCalClusters_particleIDs                  edm4hep::ParticleID                             0  ce810ab9
-BCalRecoParticle                          edm4hep::ReconstructedParticle                  0  5d2cb360
-BCalRecoParticle_particleIDs              edm4hep::ParticleID                             0  2c09a289
-BuildUpVertex                             edm4hep::Vertex                                 0  4b3ce322
-BuildUpVertex_RP                          edm4hep::ReconstructedParticle                  0  c1ce60c0
-BuildUpVertex_RP_particleIDs              edm4hep::ParticleID                             0  6bc98df2
-BuildUpVertex_V0                          edm4hep::Vertex                                 0  77941bb6
-BuildUpVertex_V0_RP                       edm4hep::ReconstructedParticle                  0  5784a361
-BuildUpVertex_V0_RP_particleIDs           edm4hep::ParticleID                             0  0d56a0e7
-ClusterMCTruthLink                        edm4hep::MCRecoClusterParticleAssociation      81  e2727d90
+```txt
+input file: higgs_recoil_out.root
+            (written with podio version: 1.2.99)
+
+datamodel model definitions stored in this file: 
+ - edm4hep (0.99.99)
+
+Frame categories in this file:
+Name                      Entries
+----------------------  ---------
+metadata                        1
+events                       9400
+configuration_metadata          1
+################################### events: 0 ####################################
+Collections:
+Name         ValueType                         Size  ID
+-----------  ------------------------------  ------  --------
+Higgs        edm4hep::ReconstructedParticle       1  88d34b01
+Muons        edm4hep::ReconstructedParticle       2  aa8128c8
+PandoraPFOs  edm4hep::ReconstructedParticle      59  fa28d9be
+Z            edm4hep::ReconstructedParticle       1  3dbac09d
+
+Parameters:
+Name                            Type           Elements
+------------------------------  -----------  ----------
+_weight                         float                 1
+alphaQCD                        float                 1
+beam_particle1                  std::string           1
+beam_particle2                  std::string           1
+beamPDG1                        int                   1
+beamPDG2                        int                   1
+beamPol1                        float                 1
+beamPol2                        float                 1
+BeamSpectrum                    std::string           1
 ...
 ```
 
-by comparing with the input file we can see our two new collections that we
-created:
-```
-Higgs                                     edm4hep::ReconstructedParticle                  1  88d34b01
-Z                                         edm4hep::ReconstructedParticle                  1  3dbac09d
-```
+You can execute `podio-dump` using the input file and compare the results to confirm that all metadata is preserved in the output file.
 
 `podio-dump` has additional options (run with `-h` to see the complete list) to
 inspect more events and even to get the values of every member of every element
 of the collections.
-
-
-You can modify the number of threads.
 
 # Plotting in python
 

--- a/gaudi_alg_higgs/setup/higgs_recoil/CMakeLists.txt
+++ b/gaudi_alg_higgs/setup/higgs_recoil/CMakeLists.txt
@@ -7,7 +7,6 @@ set(sources components/HiggsRecoil.cpp
 gaudi_add_module(tutorial
                  SOURCES ${sources}
                  LINK Gaudi::GaudiKernel
-                      Gaudi::GaudiAlgLib
                       k4FWCore::k4FWCore
                       EDM4HEP::edm4hep
                       EDM4HEP::utils

--- a/gaudi_alg_higgs/setup/higgs_recoil/components/MuonFilter.cpp
+++ b/gaudi_alg_higgs/setup/higgs_recoil/components/MuonFilter.cpp
@@ -18,23 +18,21 @@
  */
 
 #include "Gaudi/Property.h"
-#include "GaudiAlg/Transformer.h"
 
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/utils/kinematics.h"
 
-// Define BaseClass_t
-#include "k4FWCore/BaseClass.h"
+#include "k4FWCore/Transformer.h"
 
 #include <string>
 
 struct MuonFilter final
-  : Gaudi::Functional::Transformer<edm4hep::ReconstructedParticleCollection(const edm4hep::ReconstructedParticleCollection&), BaseClass_t> {
+  : public k4FWCore::Transformer<edm4hep::ReconstructedParticleCollection(const edm4hep::ReconstructedParticleCollection&)> {
   MuonFilter(const std::string& name, ISvcLocator* svcLoc)
       : Transformer(
             name, svcLoc,
-            {KeyValue("InputPFOs", "PandoraPFOs")},
-            {KeyValue("OutputMuons", "Muons")}) {
+            {KeyValues("InputPFOs", {"PandoraPFOs"})},
+            {KeyValues("OutputMuons", {"Muons"})}) {
   }
 
   edm4hep::ReconstructedParticleCollection operator()(const edm4hep::ReconstructedParticleCollection& recoColl) const override {

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -19,31 +19,26 @@
 
 from Gaudi.Configuration import INFO
 from Configurables import HiggsRecoil, MuonFilter
-from Configurables import ApplicationMgr
-from Configurables import k4DataSvc
-from Configurables import PodioOutput
-from Configurables import PodioInput
+from k4FWCore import ApplicationMgr, IOSvc
 
-data_svc = k4DataSvc("EventDataSvc")
-data_svc.input = "/home/juanmi/Downloads/ZH_40_events_ILD_DST_merged.edm4hep.root"
+io_svc = IOSvc()
+io_svc.Input = "rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I402004.Pe2e2h.eR.pL.n000.d_dstm_15090_0.edm4hep.root"
 
-inp = PodioInput()
-inp.collections = [
+io_svc.CollectionNames = [
     "PandoraPFOs",
 ]
 
-out = PodioOutput("out")
-out.outputCommands = [
+io_svc.outputCommands = [
     "drop *",
     "keep Muons",
     "keep PandoraPFOs",
     "keep Z",
     "keep Higgs",
 ]
-out.filename = "higgs_recoil_out.root"
+io_svc.Output = "higgs_recoil_out.root"
 
 # The collections that we don't drop will be present in the output file
-# out.outputCommands = ["drop Collection1"]
+# io_svc.outputCommands = ["drop Collection1"]
 
 # If we don't specify the values for the name parameters
 # they will take the default value defined in the C++ code
@@ -58,9 +53,9 @@ recoil = HiggsRecoil("HiggsRecoil",
                      ZCollection=["Z"],
                      )
 
-ApplicationMgr(TopAlg=[inp, muon, recoil, out],
+ApplicationMgr(TopAlg=[muon, recoil],
                EvtSel="NONE",
                EvtMax=-1,
-               ExtSvc=[data_svc],
+               ExtSvc=[],
                OutputLevel=INFO,
                )

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -19,31 +19,24 @@
 
 from Gaudi.Configuration import INFO
 from Configurables import HiggsRecoil, MuonFilter
-from Configurables import ApplicationMgr
-from Configurables import k4DataSvc
-from Configurables import PodioOutput
-from Configurables import PodioInput
+from k4FWCore import ApplicationMgr, IOSvc
 
-data_svc = k4DataSvc("EventDataSvc")
-data_svc.input = "/home/juanmi/Downloads/ZH_40_events_ILD_DST_merged.edm4hep.root"
-
-inp = PodioInput()
-inp.collections = [
+iosvc = IOSvc()
+iosvc.Input = "rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I402004.Pe2e2h.eR.pL.n000.d_dstm_15090_0.edm4hep.root"
+iosvc.CollectionNames = [
     "PandoraPFOs",
 ]
-
-out = PodioOutput("out")
-out.outputCommands = [
+iosvc.Output = "higgs_recoil_out.root"
+iosvc.outputCommands = [
     "drop *",
     "keep Muons",
     "keep PandoraPFOs",
     "keep Z",
     "keep Higgs",
 ]
-out.filename = "higgs_recoil_out.root"
 
 # The collections that we don't drop will be present in the output file
-# out.outputCommands = ["drop Collection1"]
+# iosvc.outputCommands = ["drop Collection1"]
 
 # If we don't specify the values for the name parameters
 # they will take the default value defined in the C++ code
@@ -58,9 +51,9 @@ recoil = HiggsRecoil("HiggsRecoil",
                      ZCollection=["Z"],
                      )
 
-ApplicationMgr(TopAlg=[inp, muon, recoil, out],
+ApplicationMgr(TopAlg=[muon, recoil],
                EvtSel="NONE",
                EvtMax=-1,
-               ExtSvc=[data_svc],
+               ExtSvc=[iosvc],
                OutputLevel=INFO,
                )

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -48,14 +48,14 @@ out.filename = "higgs_recoil_out.root"
 # If we don't specify the values for the name parameters
 # they will take the default value defined in the C++ code
 muon = MuonFilter("MuonFilter",
-                 InputPFOs="PandoraPFOs",
-                 OutputMuons="Muons",
+                 InputPFOs=["PandoraPFOs"],
+                 OutputMuons=["Muons"],
                  MinPt=10.0)
 
 recoil = HiggsRecoil("HiggsRecoil",
-                     InputMuons="Muons",
-                     HiggsCollection="Higgs",
-                     ZCollection="Z",
+                     InputMuons=["Muons"],
+                     HiggsCollection=["Higgs"],
+                     ZCollection=["Z"],
                      )
 
 ApplicationMgr(TopAlg=[inp, muon, recoil, out],

--- a/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
+++ b/gaudi_alg_higgs/setup/higgs_recoil/options/runHiggsRecoil.py
@@ -19,26 +19,31 @@
 
 from Gaudi.Configuration import INFO
 from Configurables import HiggsRecoil, MuonFilter
-from k4FWCore import ApplicationMgr, IOSvc
+from Configurables import ApplicationMgr
+from Configurables import k4DataSvc
+from Configurables import PodioOutput
+from Configurables import PodioInput
 
-io_svc = IOSvc()
-io_svc.Input = "rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I402004.Pe2e2h.eR.pL.n000.d_dstm_15090_0.edm4hep.root"
+data_svc = k4DataSvc("EventDataSvc")
+data_svc.input = "/home/juanmi/Downloads/ZH_40_events_ILD_DST_merged.edm4hep.root"
 
-io_svc.CollectionNames = [
+inp = PodioInput()
+inp.collections = [
     "PandoraPFOs",
 ]
 
-io_svc.outputCommands = [
+out = PodioOutput("out")
+out.outputCommands = [
     "drop *",
     "keep Muons",
     "keep PandoraPFOs",
     "keep Z",
     "keep Higgs",
 ]
-io_svc.Output = "higgs_recoil_out.root"
+out.filename = "higgs_recoil_out.root"
 
 # The collections that we don't drop will be present in the output file
-# io_svc.outputCommands = ["drop Collection1"]
+# out.outputCommands = ["drop Collection1"]
 
 # If we don't specify the values for the name parameters
 # they will take the default value defined in the C++ code
@@ -53,9 +58,9 @@ recoil = HiggsRecoil("HiggsRecoil",
                      ZCollection=["Z"],
                      )
 
-ApplicationMgr(TopAlg=[muon, recoil],
+ApplicationMgr(TopAlg=[inp, muon, recoil, out],
                EvtSel="NONE",
                EvtMax=-1,
-               ExtSvc=[],
+               ExtSvc=[data_svc],
                OutputLevel=INFO,
                )


### PR DESCRIPTION
BEGINRELEASENOTES
- Update "gaudi_alg_higgs" to use key4hep functional algorithms and `IOSvc`. Remove deprecated GaudiAlg library

ENDRELEASENOTES

These are changes to "gaudi_alg_higgs" tutorial factorized from #21
Closes #22